### PR TITLE
Dark mode, template fixes

### DIFF
--- a/_components/css/tabs.css
+++ b/_components/css/tabs.css
@@ -8,10 +8,11 @@
 }
 [role="tab"] {
   padding: 4px;
-  border: 1px solid var(--blue);
+  border: 1px solid var(--highlight);
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;;
-  background: var(-white);
+  color: var(--highlight);
+  background-color: var(--backgroundcolor);
   font-size: 1rem;
   cursor: pointer;
   font-family: var(--sans);
@@ -20,7 +21,7 @@
   padding-bottom: 8px;
 }
 [role="tabpanel"] {
-  border: 2px solid var(--blue);
+  border: 2px solid var(--highlight);
   padding: 4px;
   width: 100%;
 }

--- a/_src/_includes/layouts/base.webc
+++ b/_src/_includes/layouts/base.webc
@@ -9,7 +9,7 @@
     </head>
 <body>
 <div id="skip-links-container">
-<a href="#main-heading">Skip to Content</a>
+<a href="#main">Skip to Content</a>
 </div>
 <header>
 <h1 @text="site.sitename"></h1>
@@ -35,9 +35,9 @@
 </nav>
 </template>
 </header>
-<main>
+<main id="main" tabindex="-1">
 <!---If front matter has h1, will use that value, otherwise uses title--->
-<h1 id="main-heading" tabindex="-1" @text="{if (h1) {h1} else {title}}"></h1>
+<h1 webc:if"!h1exclude" @text="{if (h1) {h1} else {title}}"></h1>
 <template webc:nokeep @raw="content"></template>
 </main>
 <footer>

--- a/_src/_includes/layouts/base.webc
+++ b/_src/_includes/layouts/base.webc
@@ -37,7 +37,7 @@
 </header>
 <main id="main" tabindex="-1">
 <!---If front matter has h1, will use that value, otherwise uses title--->
-<h1 webc:if"!h1exclude" @text="{if (h1) {h1} else {title}}"></h1>
+<h1 webc:if="!h1exclude" @text="{if (h1) {h1} else {title}}"></h1>
 <template webc:nokeep @raw="content"></template>
 </main>
 <footer>

--- a/_src/_includes/layouts/css/style.css
+++ b/_src/_includes/layouts/css/style.css
@@ -4,7 +4,13 @@
     --textcolor: #222222;
     --highlight: #00247d;
 }
-
+@media (prefers-color-scheme: dark) {
+    ::root {
+--backgroundcolor: #00247d;
+--highlightcolor: #ffffff;
+--textcolor: #ffffff;
+    }
+}
 .sr-only, #skip-links-container:not(:focus-within) {
     position: absolute;
     left:  -10000px;

--- a/_src/_includes/layouts/css/style.css
+++ b/_src/_includes/layouts/css/style.css
@@ -7,7 +7,7 @@
 @media (prefers-color-scheme: dark) {
     ::root {
 --backgroundcolor: #00247d;
---highlightcolor: #ffffff;
+--highlight: #ffffff;
 --textcolor: #ffffff;
     }
 }

--- a/_src/_includes/layouts/css/style.css
+++ b/_src/_includes/layouts/css/style.css
@@ -33,6 +33,6 @@ h1, h2, h3, h4, h5, h6 {
     color: var(--highlight);
 }
 :focus-visible {
-    outline: 6px double (var(--highlight));
-    box-shadow: 0 4px var(--backgroundcolor);;
+    outline: 6px double var(--highlight);
+    box-shadow: 0 4px var(--backgroundcolor);
 }

--- a/_src/_includes/layouts/css/style.css
+++ b/_src/_includes/layouts/css/style.css
@@ -1,8 +1,8 @@
 :root {
     --sans: Verdana, Arial, sans-serif;
-    --white: #ffffff;
-    --black: #222222;
-    --blue: #00247d;
+    --backgroundcolor: #ffffff;
+    --textcolor: #222222;
+    --highlight: #00247d;
 }
 
 .sr-only, #skip-links-container:not(:focus-within) {
@@ -15,18 +15,18 @@
 }
 
 body {
-    color: var(--black);
+    color: var(--textcolor);
     font-family: var(--sans);
     font-size: 16px;
-    background-color: var(--white)
+    background-color: var(--backgroundcolor)
 }
 a, a:active, a:visited, a:focus, a:hover {
-    color: var(--blue);
+    color: var(--highlight);
 }
 h1, h2, h3, h4, h5, h6 {
-    color: var(--blue);
+    color: var(--highlight);
 }
 :focus-visible {
-    outline: 6px double (var(--blue));
-    box-shadow: 0 4px var(--white);;
+    outline: 6px double (var(--highlight));
+    box-shadow: 0 4px var(--backgroundcolor);;
 }

--- a/_src/a11y.md
+++ b/_src/a11y.md
@@ -6,4 +6,11 @@ eleventyNavigation:
     key: Accessibility
     Order: 3
 ---
-todo
+Every effort has been made to make all the content on this site accessible in line with version 2.2 of the Web Content Accessibility Guidelines. If you find an accessibility issue with this site, please file an issue on GitHub so it can be addressed.
+
+## Patterns used on this site
+
+To help increase accessibility, the following patterns were borrowed from:
+
+- The tab panel is a modified version of the [tabs with automatic activation](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-automatic/) pattern from the [W3C](https://www.w3.org/)'s [Web Accessibility Initiative.](https://www.w3.org/WAI/) The pattern has been styled differently and a few modifications have been made to the underlying HTML code so they will work as [webc components](https://www.11ty.dev/docs/languages/webc/) with [11ty](https://www.11ty.dev/), the static site generator used to build this site.
+- The focus style is a slightly modified version of the [universal focus state](https://www.erikkroes.nl/blog/the-universal-focus-state/) by [Erik Kroes.](https://www.erikkroes.nl/)

--- a/_src/a11y.md
+++ b/_src/a11y.md
@@ -6,7 +6,7 @@ eleventyNavigation:
     key: Accessibility
     Order: 3
 ---
-Every effort has been made to make all the content on this site accessible in line with version 2.2 of the Web Content Accessibility Guidelines. If you find an accessibility issue with this site, please file an issue on GitHub so it can be addressed.
+Every effort has been made to make all the content on this site accessible in line with version 2.2 of the Web Content Accessibility Guidelines. If you find an accessibility issue with this site, please [file an issue on GitHub](https://github.com/shouldiuseatabpanel/shouldiuseatabpanel.github.io/issues) so it can be addressed.
 
 ## Patterns used on this site
 

--- a/_src/index.webc
+++ b/_src/index.webc
@@ -13,12 +13,23 @@ eleventyNavigation:
 <tab-btn @index="3" @label="Test tab 3"></tab-btn>
 </tab-list>
 <tab-panel @index="1" @label="Short answer">
+<template webc:type="11ty" 11ty:type="md">
 No!
+</template>
 </tab-panel>
 <tab-panel @index="2" @label="Slightly longer answer">
+<template webc:type="11ty" 11ty:type="md">
 Hell no!
+</template>
 </tab-panel>
 <tab-panel @index="3" @label="Test tab 3">
-Test tab 3
+<template webc:type="11ty" 11ty:type="md">
+Testing a few things
+
+- List item 1
+- List item 2
+
+This is a [link](https://www.google.com/)
+</template>
 </tab-panel>
 </tab-interface>

--- a/_src/index.webc
+++ b/_src/index.webc
@@ -1,6 +1,6 @@
 ---
 title: Home
-h1: Should I Use a Tab Panel?
+h1exclude: true
 layout: layouts/base.webc
 eleventyNavigation:
     key: Home


### PR DESCRIPTION
closes #22 

Also some template tweaks and fixes such as

- add logic to template where h1 can be excluded from main content with a variable declared in front matter
- Skip to main content link now targets main element instead of h1
- fix ordering issue with nav links
- Built out content for accessibility page
- modified index.webc so markdown can be used for tabpanel content